### PR TITLE
Mock API Service

### DIFF
--- a/public/mock-data/gmi.json
+++ b/public/mock-data/gmi.json
@@ -1,0 +1,32 @@
+{
+  "30": {
+    "chartData": [
+      { "label": "≤7%", "percent": 85, "color": "#10b981" },
+      { "label": "7-8%", "percent": 2,  "color": "#f59e0b" },
+      { "label": "≥8%", "percent": 13, "color": "#ef4444" }
+    ],
+    "lastUpdated": "2025-09-01T14:11:23.837Z",
+    "activePatients": 85,
+    "averageGMI": 6.6
+  },
+  "60": {
+    "chartData": [
+      { "label": "≤7%", "percent": 83, "color": "#10b981" },
+      { "label": "7-8%", "percent": 2,  "color": "#f59e0b" },
+      { "label": "≥8%", "percent": 15, "color": "#ef4444" }
+    ],
+    "lastUpdated": "2025-09-01T14:11:23.837Z",
+    "activePatients": 110,
+    "averageGMI": 6.8
+  },
+  "90": {
+    "chartData": [
+      { "label": "≤7%", "percent": 87, "color": "#10b981" },
+      { "label": "7-8%", "percent": 2,  "color": "#f59e0b" },
+      { "label": "≥8%", "percent": 11, "color": "#ef4444" }
+    ],
+    "lastUpdated": "2025-09-01T14:11:23.837Z",
+    "activePatients": 123,
+    "averageGMI": 6.5
+  }
+}

--- a/public/mock-data/tir.json
+++ b/public/mock-data/tir.json
@@ -1,0 +1,29 @@
+{
+  "30": {
+    "chartData": [
+      { "label": "<54",     "color": "#ef4444", "percent": 3 },
+      { "label": "54-69",   "color": "#f97316", "percent": 13 },
+      { "label": "70-180",  "color": "#10b981", "percent": 70 },
+      { "label": "181-250", "color": "#f59e0b", "percent": 7 },
+      { "label": ">250",    "color": "#ef4444", "percent": 8 }
+    ]
+  },
+  "60": {
+    "chartData": [
+      { "label": "<54",     "color": "#ef4444", "percent": 2 },
+      { "label": "54-69",   "color": "#f97316", "percent": 14 },
+      { "label": "70-180",  "color": "#10b981", "percent": 73 },
+      { "label": "181-250", "color": "#f59e0b", "percent": 6 },
+      { "label": ">250",    "color": "#ef4444", "percent": 5 }
+    ]
+  },
+  "90": {
+    "chartData": [
+      { "label": "<54",     "color": "#ef4444", "percent": 3 },
+      { "label": "54-69",   "color": "#f97316", "percent": 11 },
+      { "label": "70-180",  "color": "#10b981", "percent": 73 },
+      { "label": "181-250", "color": "#f59e0b", "percent": 7 },
+      { "label": ">250",    "color": "#ef4444", "percent": 6 }
+    ]
+  }
+}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,6 +3,7 @@ import {
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection,
 } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 
@@ -16,6 +17,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
+    provideHttpClient(),
     provideRouter(routes),
     provideCharts(withDefaultRegisterables()),
   ],

--- a/src/app/core/mock-api.service.ts
+++ b/src/app/core/mock-api.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, delay, map } from 'rxjs';
+import {
+  ChartSlice,
+  GmiJson,
+  TirJson,
+  TimeRange,
+  TimeRangeKey,
+} from './models';
+
+@Injectable({ providedIn: 'root' })
+export class MockApiService {
+  constructor(private http: HttpClient) {}
+
+  private calculateRange(range: TimeRange) {
+    const now = new Date();
+    const from = new Date(now);
+    from.setDate(now.getDate() - range);
+    return { dateFrom: from.toISOString(), dateTo: now.toISOString() };
+  }
+
+  /** API (A): GMI — chart */
+  getGmiData(range: TimeRange): Observable<{
+    gmi: ChartSlice[];
+    activePatients: number;
+    averageGMI: number;
+    lastUpdated: string;
+    dateFrom: string;
+    dateTo: string;
+  }> {
+    return this.http.get<GmiJson>('/mock-data/gmi.json').pipe(
+      map((json) => {
+        const key = String(range) as TimeRangeKey;
+        const entry = json[key];
+        const { dateFrom, dateTo } = this.calculateRange(range);
+        return {
+          gmi: entry.chartData,
+          activePatients: entry.activePatients,
+          averageGMI: entry.averageGMI,
+          lastUpdated: entry.lastUpdated,
+          dateFrom,
+          dateTo,
+        };
+      }),
+      delay(200)
+    );
+  }
+
+  /** API (B): TIR — chart */
+  getTirData(range: TimeRange): Observable<ChartSlice[]> {
+    return this.http.get<TirJson>('mock-data/tir.json').pipe(
+      map((json) => {
+        const key = String(range) as TimeRangeKey;
+        const entry = json[key];
+        return entry.chartData;
+      }),
+      delay(200)
+    );
+  }
+}

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1,4 +1,5 @@
 export type TimeRange = 30 | 60 | 90;
+export type TimeRangeKey = '30' | '60' | '90';
 
 export interface FilterOption {
   id: string;
@@ -11,3 +12,18 @@ export interface ChartSlice {
   percent: number;
   color: string;
 }
+
+export interface GmiEntry {
+  chartData: ChartSlice[];
+  lastUpdated: string;
+  activePatients: number;
+  averageGMI: number;
+}
+export type GmiJson = Record<TimeRangeKey, GmiEntry>;
+
+export interface TirEntry {
+  chartData: ChartSlice[];
+  lastUpdated: string;
+  activePatients: number;
+}
+export type TirJson = Record<TimeRangeKey, TirEntry>;


### PR DESCRIPTION
This PR:
Adds two methods to MockApiService that mock HTTP calls for GMI and TIR Charts.

Adds a helper method to calculate the range.

Adds mock data for mock HTTP calls. 